### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/nordseth/Nordseth-Git/security/code-scanning/1](https://github.com/nordseth/Nordseth-Git/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege token access unless overridden. For this workflow, `contents: read` is the minimal and appropriate setting for checkout/build/test behavior shown.

Best fix (without changing functionality): in `.github/workflows/dotnet.yml`, insert:

```yml
permissions:
  contents: read
```

immediately after the `on:` trigger section (before `jobs:`), or after `name:` (either is valid). No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
