### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      weekly-batch:
+        patterns:
+          - "*"
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      weekly-batch:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds a weekly Dependabot config for `github-actions + nuget`, grouped into a single `weekly-batch` PR — matching the style used in the Nibbler repo.